### PR TITLE
bump ws version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "hyper-json-immutable-parse": "^0.1.6",
     "lscache": "^1.0.5",
     "qs": "^2.4.1",
-    "ws": "^0.7.1",
+    "ws": "^0.8.0",
     "xxhashjs": "0.0.5"
   }
 }


### PR DESCRIPTION
This version of ws uses a node v4+ compatible version of [bufferutil](https://github.com/websockets/bufferutil)

When I bumped this and linked [hyper-client-wait1](https://github.com/hypergroup/hyper-client-wait1), I could run node v4 and v5 in poe-ui apps
